### PR TITLE
Fix ceylon/ceylon-ide-eclipse#1443

### DIFF
--- a/source/com/redhat/ceylon/ide/common/doc/DocGenerator.ceylon
+++ b/source/com/redhat/ceylon/ide/common/doc/DocGenerator.ceylon
@@ -109,7 +109,7 @@ shared abstract class DocGenerator<IdeComponent>() {
     
     // see SourceInfoHover.getHoverNode(IRegion hoverRegion, CeylonParseController parseController)
     Node? getHoverNode(Tree.CompilationUnit rootNode, Integer offset) {
-        return nodes.findNode(rootNode, offset);
+        return nodes.findNode(rootNode, null, offset);
     }
     
     // see getInferredTypeHoverText(Node node, IProject project)

--- a/source/com/redhat/ceylon/ide/common/util/nodes.ceylon
+++ b/source/com/redhat/ceylon/ide/common/util/nodes.ceylon
@@ -29,6 +29,7 @@ import java.lang {
     StringBuilder
 }
 import java.util {
+    JList=List,
     JSet=Set
 }
 import java.util.regex {
@@ -162,8 +163,8 @@ shared object nodes {
         return null;
     }
 
-    shared Node? findNode(Node node, Integer startOffset, Integer endOffset = startOffset + 1) {
-        FindNodeVisitor visitor = FindNodeVisitor(startOffset, endOffset);
+    shared Node? findNode(Node node, JList<CommonToken>? tokens, Integer startOffset, Integer endOffset = startOffset + 1) {
+        FindNodeVisitor visitor = FindNodeVisitor(tokens, startOffset, endOffset);
 
         node.visit(visitor);
 


### PR DESCRIPTION
FindNodeVisitor can now get a list of tokens, and use it to improve the check whether the selection is enclosed within a given node: if the selection goes past the node, but all tokens beyond it are ignored ones
(whitespace or comments), then the selection is still considered to be within bounds of the node.

This requires a lot of changes in ceylon-ide-eclipse, so I don’t want to just push it to master.