### PR TITLE
Fix ceylon/ceylon-ide-eclipse#1669

### DIFF
--- a/source/com/redhat/ceylon/ide/common/completion/codeCompletions.ceylon
+++ b/source/com/redhat/ceylon/ide/common/completion/codeCompletions.ceylon
@@ -695,7 +695,7 @@ void appendMembersToEquals(Unit unit, String indent, StringBuilder result,
         }
     }
     if (found) {
-        result.deleteTerminal(4 - indent.size);
+        result.deleteTerminal(4 + indent.size);
         result.append(";");
     } else {
         result.append("true;");


### PR DESCRIPTION
This commit, as far as I can tell, fixes ceylon/ceylon-ide-eclipse#1669. It also seems to make sense to me – you need to delete the four characters `" && "` in *addition* to the indentation and line break.

However, since a previous commit – 8731041 by @bjansen – touched *exclusively* that line, it seems odd that it should be incorrect… can someone quickly review?